### PR TITLE
Add move_base_topic option

### DIFF
--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -91,7 +91,7 @@ private:
   tf::TransformListener tf_listener_;
 
   Costmap2DClient costmap_client_;
-  actionlib::SimpleActionClient<move_base_msgs::MoveBaseAction>
+  std::unique_ptr<actionlib::SimpleActionClient<move_base_msgs::MoveBaseAction>>
       move_base_client_;
   frontier_exploration::FrontierSearch search_;
   ros::Timer exploring_timer_;

--- a/explore/launch/explore.launch
+++ b/explore/launch/explore.launch
@@ -1,6 +1,7 @@
 <launch>
 <node pkg="explore_lite" type="explore" respawn="false" name="explore" output="screen">
   <param name="robot_base_frame" value="base_link"/>
+  <param name="move_base_topic" value="move_base"/>
   <param name="costmap_topic" value="map"/>
   <param name="costmap_updates_topic" value="map_updates"/>
   <param name="visualize" value="true"/>


### PR DESCRIPTION
Removes default move base topic, makes it usable with custom topics and namespaces.